### PR TITLE
Pylint load xml for runtime check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ warn_unused_ignores = true
 ignore = [
   "tests"
 ]
+unsafe-load-any-extension = [
+  "lxml"
+]
 
 [tool.pylint.BASIC]
 good-names = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ warn_unused_ignores = true
 ignore = [
   "tests"
 ]
-unsafe-load-any-extension = [
+extension-pkg-whitelist = [
   "lxml"
 ]
 


### PR DESCRIPTION
# Proposed Changes

Should fix `pytrafikverket/trafikverket.py:35:20: I1101: Module 'lxml.etree' has no 'Element' member, but source is unavailable. Consider adding this module to extension-pkg-allow-list if you want to perform analysis based on run-time introspection of living objects. (c-extension-no-member)`

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
